### PR TITLE
implement log.New

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -53,6 +53,11 @@ func Discard() *Logger {
 	}
 }
 
+// New -> log.New
+func New(out io.Writer, prefix string, flag int) *log.Logger {
+	return log.New(out, prefix, flag)
+}
+
 // SetOutput -> log.SetOutput
 func (this *Logger) SetOutput(w io.Writer) {
 	if this == nil {


### PR DESCRIPTION
golang builtin log has [`log.New`](https://golang.org/pkg/log/#New) which is used throughout some of my old code. In order for this library to be a true drop-in it'll need this func.